### PR TITLE
insert installation of ros-base before intalling roseus.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ rosrun euslisp irteusgl
 sudo sh -c 'echo "deb http://packages.ros.org/ros-shadow-fixed/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list'
 wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
 sudo apt-get update
+sudo apt-get install ros-indigo-ros-base
 sudo apt-get install ros-indigo-roseus
 # you may have to reboot
 echo "source /opt/ros/indigo/setup.bash" >> ~/.bashrc


### PR DESCRIPTION
I use Ubuntu 14.04, and I come up with the error which says "there are no setup.sh".
Maybe it is caused by I forgot the apt-get update step, but I send pull request in case of others have same trouble as me.
